### PR TITLE
SetSelect api command

### DIFF
--- a/djangosphinx/models.py
+++ b/djangosphinx/models.py
@@ -241,6 +241,8 @@ class SphinxQuerySet(object):
         dict = self.__dict__.copy()
         if self._result_cache:
             dict['_result_cache'] = None
+            dict['_metadata'] = {}
+            dict['_SphinxQuerySet__metadata'] = {}
         return dict
 
     def __len__(self):
@@ -416,6 +418,10 @@ class SphinxQuerySet(object):
         c.__dict__.update(self.__dict__.copy())
         for k, v in kwargs.iteritems():
             setattr(c, k, v)
+        # reset cached data
+        c._result_cache = None
+        c.__metadata = {}
+        c._SphinxQuerySet__metadata = {}
         return c
     
     def _sphinx(self):


### PR DESCRIPTION
Hi there, David

I did a quick job of adding in a SetSelect command. I'm sure you know about it, its very useful for using more advanced features of sphinx. It has been introduced in Sphinx 0.9.9 RC1

An example use-case is to find documents that have been published anywhere between a certain date range.
http://sphinxsearch.com/forum/view.html?id=3577

Once SetSelect has been set, filters can be applied to the search query.
http://www.sphinxsearch.com/docs/current.html#api-func-setselect
