### PR TITLE
Export djangosphinx/config.py as console_script entrypoint

### DIFF
--- a/djangosphinx/config.py
+++ b/djangosphinx/config.py
@@ -53,4 +53,9 @@ else:
         'DATABASE_NAME': settings.DATABASE_NAME,
     })
 
-print render_to_string(getattr(settings, 'SPHINX_CONFIG_TEMPLATE', 'conf/sphinx.conf'), context)
+def main():
+    print render_to_string(getattr(settings, 
+        'SPHINX_CONFIG_TEMPLATE', 'conf/sphinx.conf'), context)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setup(
     description = 'An integration layer bringing Django and Sphinx Search together.',
     packages=find_packages(),
     include_package_data=True,
+    entry_points="""
+    [console_scripts]
+    django-sphinx-config=djangosphinx.config:main
+    """,
     classifiers=[
         "Framework :: Django",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Refering to .../djangosphnix/config.py  from searchd commandline is not always comfortable, when django-sphnix installed via virtualenv or buildout.

I make simple patch to create bin/django-sphinx-config this cases. Old style executing of config.py also should work.
