### PR TITLE
unsigned long int for range selection

### DIFF
--- a/djangosphinx/models.py
+++ b/djangosphinx/models.py
@@ -470,7 +470,7 @@ class SphinxQuerySet(object):
                                 value -= (1.0/MAX_INT)
                             else:
                                 value -= 1
-                        _max = -MAX_INT
+                        _max = 0
                         if is_float:
                             _max = float(_max)
                         args = (name, _max, value, exclude)


### PR DESCRIPTION
mimimal value is 0 and not -MAX_INT (this prevented djangosphinx from being used with python >= 2.7)
as pack('>2L', min, max) is being used, where L is an unsigned long int.
Previous python versions accepted the input with a deprecation warning.
